### PR TITLE
update URL to load 0.6 schemas from ome/ngff_spec

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -10,7 +10,7 @@ export const FILE_NOT_FOUND = "File not found";
 export function getSchemaUrl(schemaName, version) {
   if (version.includes("0.6")) {
     // return `https://raw.githubusercontent.com/ome/ngff-spec/refs/heads/main/ngff_spec/schemas/${schemaName}.schema`;
-    return `https://raw.githubusercontent.com/jo-mueller/ngff-spec/refs/heads/RFC5/ngff_spec/schemas/${schemaName}.schema`;
+    return `https://raw.githubusercontent.com/ome/ngff-spec/refs/heads/main/ngff_spec/schemas/${schemaName}.schema`;
     // return `https://raw.githubusercontent.com/jo-mueller/ngff-spec/refs/heads/update-rfc5-schemas/ngff_spec/schemas/${schemaName}.schema`;
     // https://github.com/bogovicj/ngff-rfc5-coordinate-transformation-examples/issues/5
     // return `https://raw.githubusercontent.com/bogovicj/ngff/6f692498744ad9dc77c50541fe8b78c5886b4c05/schemas/${schemaName}.schema`;


### PR DESCRIPTION
@will-moore small update to load the schemas from ngff_spec rather than my fork. Can be merged after this is merged: 

- https://github.com/ome/ngff-spec/pull/17