### PR TITLE
fix: get schemas from ngff-spec repo

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -8,7 +8,7 @@ export const FILE_NOT_FOUND = "File not found";
 
 export function getSchemaUrl(schemaName, version) {
   if (version.includes("0.6")) {
-    return `https://raw.githubusercontent.com/jo-mueller/ngff-spec/refs/heads/update-RFC5/schemas/${schemaName}.schema`;
+    return `https://raw.githubusercontent.com/ome/ngff-spec/refs/heads/main/schemas/${schemaName}.schema`;
   }
   return `https://ngff.openmicroscopy.org/${version}/schemas/${schemaName}.schema`;
 }


### PR DESCRIPTION
Hi @will-moore, with https://github.com/ome/ngff-spec/pull/67 merged, this is the correct place from which to load the schemas now.